### PR TITLE
✨ [feat] #3 일정 생성하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/schedulemanageapp/ScheduleManageAppApplication.java
+++ b/src/main/java/com/example/schedulemanageapp/ScheduleManageAppApplication.java
@@ -2,7 +2,9 @@ package com.example.schedulemanageapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ScheduleManageAppApplication {
 

--- a/src/main/java/com/example/schedulemanageapp/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/schedulemanageapp/common/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.example.schedulemanageapp.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+//    @Temporal(TemporalType.TIMESTAMP) 생략가능
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/schedulemanageapp/common/exception/base/CustomException.java
+++ b/src/main/java/com/example/schedulemanageapp/common/exception/base/CustomException.java
@@ -1,0 +1,16 @@
+package com.example.schedulemanageapp.common.exception.base;
+
+import com.example.schedulemanageapp.common.exception.code.enums.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,29 @@
+package com.example.schedulemanageapp.domain.schedule.controller;
+
+
+import com.example.schedulemanageapp.common.exception.code.enums.SuccessCode;
+import com.example.schedulemanageapp.common.response.ApiResponseDto;
+import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
+import com.example.schedulemanageapp.domain.schedule.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<Void>> createSchedule(@RequestBody @Valid final ScheduleCreateRequestDto scheduleCreateRequestDto) {
+        scheduleService.createSchedule(scheduleCreateRequestDto);
+        return ResponseEntity.status(201)
+                .body(ApiResponseDto.success(SuccessCode.SCHEDULE_CREATE_SUCCESS, "/api/schedules"));
+    }
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/request/ScheduleCreateRequestDto.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/request/ScheduleCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.schedulemanageapp.domain.schedule.dto.request;
+import jakarta.validation.constraints.*;
+
+public record ScheduleCreateRequestDto(
+
+        @NotNull Long userId,
+
+        @NotBlank(message = "할 일은 제목은 공백일 수 없습니다.") @Size(max = 10, message = "최대 10자까지 가능합니다.")
+        String todoTitle,
+
+        @NotBlank(message = "할 일은 내용은 공백일 수 없습니다.") @Size(max = 200, message = "최대 200자까지 가능합니다.")
+        String todoContent
+) {
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/entity/Schedule.java
@@ -1,0 +1,37 @@
+package com.example.schedulemanageapp.domain.schedule.entity;
+
+import com.example.schedulemanageapp.common.entity.BaseTimeEntity;
+import com.example.schedulemanageapp.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "schedule")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long scheduleId;
+
+    @Column(name="todo_title", nullable = false)
+    private String todoTitle;
+
+    @Column(name="todo_content", nullable = false)
+    private String todoContent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users users;
+
+    // 생성자
+    public Schedule(String todoTitle, String todoContent, Users users) {
+        this.todoTitle = todoTitle;
+        this.todoContent = todoContent;
+        this.users = users;
+    }
+
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,9 @@
+package com.example.schedulemanageapp.domain.schedule.repository;
+
+import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,34 @@
+package com.example.schedulemanageapp.domain.schedule.service;
+
+import com.example.schedulemanageapp.common.exception.base.CustomException;
+import com.example.schedulemanageapp.common.exception.code.enums.ErrorCode;
+import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
+import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
+import com.example.schedulemanageapp.domain.schedule.repository.ScheduleRepository;
+import com.example.schedulemanageapp.domain.users.entity.Users;
+import com.example.schedulemanageapp.domain.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createSchedule(ScheduleCreateRequestDto scheduleCreateRequestDto){
+        Users user = userRepository.findById(scheduleCreateRequestDto.userId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Schedule schedule = new Schedule(
+                scheduleCreateRequestDto.todoTitle(),
+                scheduleCreateRequestDto.todoContent(),
+                user
+        );
+        scheduleRepository.save(schedule);
+    }
+
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/users/entity/Users.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/users/entity/Users.java
@@ -1,0 +1,28 @@
+package com.example.schedulemanageapp.domain.users.entity;
+
+import com.example.schedulemanageapp.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Users extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(name="user_name", nullable = false)
+    private String userName;
+
+    @Column(name="password", nullable = false)
+    private String password;
+
+    @Column(name="email", nullable = false)
+    private String email;
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #3 

## Key Changes 🔑
성공 시 다음과 같이 반환됩니다.
![image](https://github.com/user-attachments/assets/f9576148-c0b1-4b2b-8caf-9cfb17e680c4)

실패 시 다음과 같이 반환됩니다. (Lv 5의 유효성 검사도 함께 진행되어있습니다.)
![image](https://github.com/user-attachments/assets/211b8956-7f25-4469-b3fb-904c271c8bdb)

```java
@Getter
@Entity
@Table(name = "schedule")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Schedule extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long scheduleId;

    @Column(name="todo_title", nullable = false)
    private String todoTitle;

    @Column(name="todo_content", nullable = false)
    private String todoContent;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "user_id", nullable = false)
    private Users users;

    // 생성자
    public Schedule(String todoTitle, String todoContent, Users users) {
        this.todoTitle = todoTitle;
        this.todoContent = todoContent;
        this.users = users;
    }

}
```
JPA는 엔티티를 생성할 때 `new`를 사용하지 않고 리플렉션을 사용하므로, 기본 생성자(인자 없는 생성자)가 꼭 필요합니다. 그리고 접근 제어자는 `public` 또는 `protected` 이어야 JPA가 접근할 수 있습니다.


**그렇다면 왜 public 이 아니라 protected를 사용했는지 ?** 
`public`으로 하면 외부에서 직접 생성할 수 있으므로 `protected` 로 제한해서 JPA만 쓸 수 있게 했습니다.

따라서 `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 를 통해 파라미터가 없는 기본 생성자를 자동으로 만들어 주었습니다.



## To Reviewers 📢
BaseTimeEntity 관련 아티클도 작성했습니다. 
https://yeunever.tistory.com/36
