### PR TITLE
✨ [feat] #5 전체 일정, 선택 일정 조회하기

### DIFF
--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
@@ -4,14 +4,12 @@ package com.example.schedulemanageapp.domain.schedule.controller;
 import com.example.schedulemanageapp.common.exception.code.enums.SuccessCode;
 import com.example.schedulemanageapp.common.response.ApiResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
 import com.example.schedulemanageapp.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/schedules")
@@ -26,4 +24,10 @@ public class ScheduleController {
         return ResponseEntity.status(201)
                 .body(ApiResponseDto.success(SuccessCode.SCHEDULE_CREATE_SUCCESS, "/api/schedules"));
     }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponseDto<ScheduleDetailResponseDto>> getSchedule(@PathVariable final Long scheduleId) {
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_READ_SUCCESS, scheduleService.getSchedule(scheduleId), "/api/schedules/"));
+    }
+
 }

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
@@ -5,11 +5,14 @@ import com.example.schedulemanageapp.common.exception.code.enums.SuccessCode;
 import com.example.schedulemanageapp.common.response.ApiResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleListResponseDto;
 import com.example.schedulemanageapp.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedules")
@@ -30,4 +33,13 @@ public class ScheduleController {
         return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_READ_SUCCESS, scheduleService.getSchedule(scheduleId), "/api/schedules/"));
     }
 
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<List<ScheduleListResponseDto>>> searchAllSchedules(
+            @RequestParam(required = false) String updatedDate, // 조회 기준이 되는 수정일
+            @RequestParam(required = false) Long userId // 조회 대상의 사용자 ID, null 이면 전체 조회
+    ) {
+        return ResponseEntity.ok(
+                ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_SUCCESS, scheduleService.findSchedulesByConditions(updatedDate, userId), "/api/schedules/search")
+        );
+    }
 }

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleDetailResponseDto.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleDetailResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.schedulemanageapp.domain.schedule.dto.response;
+
+import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ScheduleDetailResponseDto(
+        Long scheduleId,
+        String todoTitle,
+        String todoContent,
+        String userName,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ScheduleDetailResponseDto from(Schedule schedule) {
+        return ScheduleDetailResponseDto.builder()
+                .scheduleId(schedule.getScheduleId())
+                .todoTitle(schedule.getTodoTitle())
+                .todoContent(schedule.getTodoContent())
+                .userName(schedule.getUsers().getUserName()) // Users 엔티티에서 가져옴
+                .createdAt(schedule.getCreatedAt())
+                .updatedAt(schedule.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleListResponseDto.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleListResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.schedulemanageapp.domain.schedule.dto.response;
+import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
+
+public record ScheduleListResponseDto(
+        Long scheduleId,
+        String todoTitle,
+        String todoContent,
+        String userName // 사용자 정보 포함
+) {
+    public static ScheduleListResponseDto from(Schedule schedule) {
+        return new ScheduleListResponseDto(
+                schedule.getScheduleId(),
+                schedule.getTodoTitle(),
+                schedule.getTodoContent(),
+                schedule.getUsers().getUserName() // Users 엔티티에서 이름 가져오기
+        );
+    }
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
@@ -2,8 +2,26 @@ package com.example.schedulemanageapp.domain.schedule.repository;
 
 import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    /* - userId가 null이 아니면 해당 유저의 일정만 필터링
+       - updatedDate가 null이 아니면 수정일 기준 이후의 일정만 필터링
+     */
+    @Query("""
+        SELECT s FROM Schedule s
+        WHERE (:userId IS NULL OR s.users.id = :userId)
+          AND (:updatedDate IS NULL OR s.updatedAt >= :updatedDate)
+        ORDER BY s.updatedAt DESC
+    """)
+    List<Schedule> findSchedulesByConditions(
+        Long userId,
+        LocalDateTime updatedDate
+    );
 }

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
@@ -1,8 +1,10 @@
 package com.example.schedulemanageapp.domain.schedule.service;
 
 import com.example.schedulemanageapp.common.exception.base.CustomException;
+import com.example.schedulemanageapp.common.exception.base.NotFoundException;
 import com.example.schedulemanageapp.common.exception.code.enums.ErrorCode;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
 import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
 import com.example.schedulemanageapp.domain.schedule.repository.ScheduleRepository;
 import com.example.schedulemanageapp.domain.users.entity.Users;
@@ -18,6 +20,12 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final UserRepository userRepository;
 
+
+    /**
+     * 일정 생성
+     * - 유저 ID를 통해 유저 정보를 조회한 후, 할일 제목과 내용을 포함한 Schedule 엔티티를 생성 및 저장
+     * @param scheduleCreateRequestDto 생성 요청 DTO
+     */
     @Transactional
     public void createSchedule(ScheduleCreateRequestDto scheduleCreateRequestDto){
         Users user = userRepository.findById(scheduleCreateRequestDto.userId())

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
@@ -5,6 +5,7 @@ import com.example.schedulemanageapp.common.exception.base.NotFoundException;
 import com.example.schedulemanageapp.common.exception.code.enums.ErrorCode;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleListResponseDto;
 import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
 import com.example.schedulemanageapp.domain.schedule.repository.ScheduleRepository;
 import com.example.schedulemanageapp.domain.users.entity.Users;
@@ -12,6 +13,11 @@ import com.example.schedulemanageapp.domain.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,4 +45,38 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
     }
 
+
+    /**
+     * 선택 일정 상세 조회
+     * - 일정 ID로 Schedule을 조회하여 DTO로 변환 후 반환
+     * @param scheduleId 조회할 일정 ID
+     * @return 일정 상세 정보 DTO
+     */
+    @Transactional
+    public ScheduleDetailResponseDto getSchedule(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .map(ScheduleDetailResponseDto::from)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.SCHEDULE_NOT_FOUND));
+    }
+
+    /**
+     * 조건에 따른 전체 일정 목록 조회
+     * - userId와 updatedDate를 조건으로 조회 (둘 다 null 가능)
+     * - updatedDate는 YYYY-MM-DD 형식으로 입력되어야 함
+     * - 수정일 기준 내림차순 정렬
+     * @param updatedDateStr 수정일 (String, YYYY-MM-DD)
+     * @param userId 유저 ID (nullable)
+     * @return 일정 목록 DTO 리스트
+     */
+    @Transactional
+    public List<ScheduleListResponseDto> findSchedulesByConditions(String updatedDateStr, Long userId) {
+        LocalDateTime updatedDate = null;
+        if (updatedDateStr != null && !updatedDateStr.isBlank()) {
+            updatedDate = LocalDate.parse(updatedDateStr).atStartOfDay();
+        }
+
+        return scheduleRepository.findSchedulesByConditions(userId, updatedDate).stream()
+                .map(ScheduleListResponseDto::from)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #5

## Key Changes 🔑
전체 일정 조회 성공 시(필터링 적용X) 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/58bd2581-9b89-41ea-955c-5b54998e6d73)

수정일을 기준으로 조회 시  다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/3a159e04-4243-4356-962a-ac56a13ed74f)

조건에 해당하는 글이 없을 경우, 빈 리스트로 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/994bfb23-eaae-4114-b183-5a942e92d442)

선택 일정 조회 성공 시  다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/873837c2-5a3e-4a6a-b5a1-b4eecc1bf3dd)

일정이 존재하지 않을 경우, 다음과 같이 에러를 반환합니다.
![image](https://github.com/user-attachments/assets/18484c3d-9719-45b4-9867-07775fa372fa)

## 구현 방법 🖊️

▶️ SchduleRepository의 JPQL 쿼리 설명

```java
@Query("""
    SELECT s FROM Schedule s
    WHERE (:userId IS NULL OR s.users.id = :userId)
      AND (:updatedDate IS NULL OR s.updatedAt >= :updatedDate)
    ORDER BY s.updatedAt DESC
""")
List<Schedule> findSchedulesByConditions(
        @Param("userId") Long userId,
        @Param("updatedDate") LocalDateTime updatedDate
);
```

| 조건 | 설명 |
| --- | --- |
| `:userId IS NULL OR s.users.id = :userId` | userId가 null이면 조건을 무시하고, 값이 있으면 해당 유저의 일정만 필터링 |
| `:updatedDate IS NULL OR s.updatedAt >= :updatedDate` | updatedDate가 null이면 필터링하지 않고, 값이 있으면 해당 날짜 이후만 조회 |
| `ORDER BY s.updatedAt DESC` | 수정일 기준 내림차순 정렬 |


▶️ ScheduleService 코드 설명

```java
 @Transactional
    public List<ScheduleListResponseDto> findSchedulesByConditions(String updatedDateStr, Long userId) {
        LocalDateTime updatedDate = null; // 쿼리에서 사용할 LocalDateTime 타입의 updatedDate 변수 선언
        if (updatedDateStr != null && !updatedDateStr.isBlank()) {
            updatedDate = LocalDate.parse(updatedDateStr).atStartOfDay(); // 날짜 파싱 및 시작 시간 설정
        }

        return scheduleRepository.findSchedulesByConditions(userId, updatedDate).stream()
                .map(ScheduleListResponseDto::from) // Entity → DTO 변환
                .collect(Collectors.toList()); // 변환된 DTO를 List로 수집
    }
```

`updatedDateStr`: 날짜 필터 조건 (ex. "2024-04-01") → String 형태로 들어오지만 `LocalDateTime`으로 변환해서 쿼리에 사용했으므로 변환하는 과정이 필요하다.

```java
updatedDate = LocalDate.parse(updatedDateStr).atStartOfDay();
```

- `String`으로 들어온 날짜 (예: `"2025-03-31"`)를 `LocalDate`로 변환한 뒤,
- `atStartOfDay()`를 붙여 00:00:00 시각의 `LocalDateTime` 객체로 변환
- 이렇게 하면 `updated_at >= 2025-03-31 00:00:00` 조건으로 비교할 수 있게 된당 !!

## To Reviewers 📢
- [ ]  **전체 일정 조회(등록된 일정 불러오기)**
    - [ ]  다음 **조건**을 바탕으로 등록된 일정 목록을 전부 조회
        - [ ]  `수정일` (형식 : YYYY-MM-DD)
        - [ ]  `작성자명`
    - [ ]  조건 중 한 가지만을 충족하거나, 둘 다 충족을 하지 않을 수도, 두 가지를 모두 충족할 수도 있습니다.
    - [ ]  `수정일` 기준 내림차순으로 정렬하여 조회


해당 내용을 만족시키려고 하다보니, 쿼리 메서드가 너무 복잡한 것 같아서 `@Query` 어노테이션을 사용했습니다. 그런데 구현하고 보니,
`List<Schedule> findByUsers_IdAndUpdatedAtAfterOrderByUpdatedAtDesc(Long userId, LocalDateTime updatedDate);` 이렇게 쿼리 메서드로도 작성 가능한 것을 알게 되었습니다.
두 가지 방식 중에 어떠한 경우에, 어떤 방식을 택하는 것이 좋은지 궁급합니다 !

