### PR TITLE
✨ [feat] #17 일정 페이징 조회하기(페이지네이션)

### DIFF
--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
@@ -12,10 +12,12 @@ import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleUpdate
 import com.example.schedulemanageapp.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedules")
@@ -37,12 +39,13 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponseDto<List<ScheduleListResponseDto>>> searchAllSchedules(
-            @RequestParam(required = false) String updatedDate, // 조회 기준이 되는 수정일
-            @RequestParam(required = false) Long userId // 조회 대상의 사용자 ID, null 이면 전체 조회
+    public ResponseEntity<ApiResponseDto<Page<ScheduleListResponseDto>>> searchAllSchedules(
+            @RequestParam(required = false) String updatedDate,
+            @RequestParam(required = false) Long userId,
+            @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(
-                ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_SUCCESS, scheduleService.findSchedulesByConditions(updatedDate, userId), "/api/schedules")
+                ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_SUCCESS, scheduleService.findSchedulesByConditions(updatedDate, userId, pageable), "/api/schedules")
         );
     }
 

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleListResponseDto.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/ScheduleListResponseDto.java
@@ -5,14 +5,16 @@ public record ScheduleListResponseDto(
         Long scheduleId,
         String todoTitle,
         String todoContent,
-        String userName // 사용자 정보 포함
+        String userName, // 사용자 정보 포함
+        int commentCount
 ) {
     public static ScheduleListResponseDto from(Schedule schedule) {
         return new ScheduleListResponseDto(
                 schedule.getScheduleId(),
                 schedule.getTodoTitle(),
                 schedule.getTodoContent(),
-                schedule.getUsers().getUserName() // Users 엔티티에서 이름 가져오기
+                schedule.getUsers().getUserName(), // Users 엔티티에서 이름 가져오기
+                schedule.getComments().size()
         );
     }
 }

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/repository/ScheduleRepository.java
@@ -1,27 +1,23 @@
 package com.example.schedulemanageapp.domain.schedule.repository;
 
 import com.example.schedulemanageapp.domain.schedule.entity.Schedule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
-    /* - userId가 null이 아니면 해당 유저의 일정만 필터링
-       - updatedDate가 null이 아니면 수정일 기준 이후의 일정만 필터링
-     */
-    @Query("""
-        SELECT s FROM Schedule s
-        WHERE (:userId IS NULL OR s.users.userId = :userId)
-          AND (:updatedDate IS NULL OR s.updatedAt >= :updatedDate)
-        ORDER BY s.updatedAt DESC
-    """)
-    List<Schedule> findSchedulesByConditions(
-        Long userId,
-        LocalDateTime updatedDate
-    );
+    // 조건 기반 페이징 쿼리
+    Page<Schedule> findByUsers_UserId(Long userId, Pageable pageable);
+
+    Page<Schedule> findByUpdatedAtAfter(LocalDateTime updatedDate, Pageable pageable);
+
+    Page<Schedule> findByUsers_UserIdAndUpdatedAtAfter(Long userId, LocalDateTime updatedDate, Pageable pageable);
+
+    Page<Schedule> findAll(Pageable pageable); // 기본 findAll도 사용 가능
+
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #17 

## Key Changes 🔑
`Pageable`을 이용한 일정 목록 페이징 조회 기능을 구현했습니다.

`Pageable`, `Page`, `@PageableDefault` 정리
| 기술 요소 | 설명 |
| --- | --- |
| `Pageable` | 클라이언트 요청에서 페이지 번호, 크기, 정렬을 담은 객체 |
| `Page<T>` | 조회 결과 + 페이징 메타정보를 함께 담는 Spring 제공 객체 |
| `@PageableDefault` | 페이지 번호/크기/정렬 기준의 기본값 설정용 어노테이션 |

```java
@PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
```

요청 파라미터로 넘어오는 페이지 정보(`page`, `size`, `sort`)에 기본값을 설정한 것으로 클라이언트가 아무 `page`, `size`, `sort`를 전달하지 않아도 자동으로 `0페이지`, `10개`, `updatedAt 내림차순`으로 요청된 것처럼 동작합니다.

▶️ ScheduleRepository

```java
// 1. userId + updatedDate 조합
Page<Schedule> findByUsers_UserIdAndUpdatedAtAfter(Long userId, LocalDateTime updatedDate, Pageable pageable);

// 2. userId만 있을 때
Page<Schedule> findByUsers_UserId(Long userId, Pageable pageable);

// 3. updatedDate만 있을 때
Page<Schedule> findByUpdatedAtAfter(LocalDateTime updatedDate, Pageable pageable);

// 4. 전체 조건 없이 조회
Page<Schedule> findAll(Pageable pageable);

```

`Page<T>` 객체를 JSON으로 직렬화했을 때 나오는 표준 페이징 메타데이터는 다음과 같습니다.
![image](https://github.com/user-attachments/assets/bf101cc0-6bfd-4d01-8056-9a07633cbce1)

```java
{
    "timestamp": "2025-04-04T03:19:24.5155479",
    "statusCode": 200,
    "httpStatus": "OK",
    "code": "SS2001",
    "message": "일정 목록을 성공적으로 조회했습니다.",
    "path": "/api/schedules",
    "data": {
        "content": [
            {
                "scheduleId": 2,
                "todoTitle": "Spring 과제",
                "todoContent": "JPA 구현",
                "userName": "예은",
                "commentCount": 0
            },
            {
                "scheduleId": 1,
                "todoTitle": "정처기 실기",
                "todoContent": "시험 공부하기",
                "userName": "예은",
                "commentCount": 1
            }
        ],
        "pageable": {
            "pageNumber": 0,
            "pageSize": 10,
            "sort": {
                "sorted": true,
                "empty": false,
                "unsorted": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "last": true,
        "totalElements": 2,
        "totalPages": 1,
        "first": true,
        "numberOfElements": 2,
        "size": 10,
        "number": 0,
        "sort": {
            "sorted": true,
            "empty": false,
            "unsorted": false
        },
        "empty": false
    }
}
```
| 필드명 | 설명 |
| --- | --- |
| `pageable` | 클라이언트가 요청한 페이지 정보 객체 |
| `pageable.pageNumber` | 현재 페이지 번호 (0부터 시작) |
| `pageable.pageSize` | 한 페이지에 보여줄 데이터 개수 |
| `pageable.offset` | 전체 데이터 중 현재 페이지가 시작되는 위치 (예: `0`이면 첫 번째) |
| `pageable.sort` | 어떤 필드로 정렬했는지 (여기선 `updatedAt`, 내림차순) |
| `paged` | 페이지 요청이 적용되었는지 여부 (`true`) |
| `unpaged` | 페이지네이션이 적용되지 않았는지 여부 (`false`) |

| 필드명 | 설명 |
| --- | --- |
| `last` | 마지막 페이지인지 여부 (`true`) |
| `first` | 첫 페이지인지 여부 (`true`) |
| `totalElements` | 조건에 맞는 전체 데이터 수 (예: 2개) |
| `totalPages` | 전체 페이지 수 (예: 1페이지) |
| `number` | 현재 페이지 번호 (0부터 시작) |
| `numberOfElements` | 현재 페이지에 포함된 데이터 개수 (예: 2개) |
| `size` | 한 페이지당 크기 (예: 10개 요청함) |
| `empty` | 현재 페이지가 비어 있는지 여부 (`false` → 내용 있음) |
## To Reviewers 📢
`PageResponseDto` 등을 만들어서 커스텀해서 반환하는 것이 더 좋은 방식인가요 ? 스프링의 기본 `Pageable` 인터페이스를 사용하니까 JSON 반환 값이 알아보기 힘들다는 느낌이 드는데 다른 좋은 방식이 있다면 알고 싶습니다 !

++ 공부하다보니, QueryDSL로 바꾸면 더 유연하고 유지보수하기 간편한 것 같은데 QueryDSL 적용을 추천하시나요 ?