### PR TITLE
♻️ [refac] #19  Schedule 페이징 응답에 PageResponseDto 적용

### DIFF
--- a/src/main/java/com/example/schedulemanageapp/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/schedulemanageapp/common/entity/BaseTimeEntity.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
     @CreatedDate
-    @Column(updatable = false)
-//    @Temporal(TemporalType.TIMESTAMP) 생략가능
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/controller/ScheduleController.java
@@ -6,13 +6,13 @@ import com.example.schedulemanageapp.common.response.ApiResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleDeleteRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleUpdateReqeustDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.PageResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleListResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleUpdateResponseDto;
 import com.example.schedulemanageapp.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -39,7 +39,7 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponseDto<Page<ScheduleListResponseDto>>> searchAllSchedules(
+    public ResponseEntity<ApiResponseDto<PageResponseDto<ScheduleListResponseDto>>> searchAllSchedules(
             @RequestParam(required = false) String updatedDate,
             @RequestParam(required = false) Long userId,
             @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/PageResponseDto.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/dto/response/PageResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.schedulemanageapp.domain.schedule.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponseDto<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return new PageResponseDto<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanageapp/domain/schedule/service/ScheduleService.java
@@ -6,6 +6,7 @@ import com.example.schedulemanageapp.common.exception.code.enums.ErrorCode;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleCreateRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleDeleteRequestDto;
 import com.example.schedulemanageapp.domain.schedule.dto.request.ScheduleUpdateReqeustDto;
+import com.example.schedulemanageapp.domain.schedule.dto.response.PageResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleDetailResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleListResponseDto;
 import com.example.schedulemanageapp.domain.schedule.dto.response.ScheduleUpdateResponseDto;
@@ -73,7 +74,7 @@ public class ScheduleService {
      * @return 조건에 맞는 일정 리스트를 ScheduleListResponseDto 형태로 Page 객체에 담아 반환
      */
     @Transactional
-    public Page<ScheduleListResponseDto> findSchedulesByConditions(String updatedDateStr, Long userId, Pageable pageable) {
+    public PageResponseDto<ScheduleListResponseDto> findSchedulesByConditions(String updatedDateStr, Long userId, Pageable pageable) {
 
         // 문자열로 받은 날짜 필터를 LocalDateTime으로 변환
         LocalDateTime updatedDate = null;
@@ -100,8 +101,11 @@ public class ScheduleService {
             schedules = scheduleRepository.findAll(pageable);
         }
 
-        // Schedule 엔티티를 DTO로 변환하여 반환
-        return schedules.map(ScheduleListResponseDto::from);
+        // Schedule → ScheduleListResponseDto 매핑
+        Page<ScheduleListResponseDto> dtoPage = schedules.map(ScheduleListResponseDto::from);
+
+        // Page → PageResponseDto로 감싸서 반환
+        return PageResponseDto.from(dtoPage);
     }
 
     /**


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #19

## Key Changes 🔑
![image](https://github.com/user-attachments/assets/7f7f6eec-a357-46ab-b5e0-1d02253d8fdb)

| 구분 | 설명 |
|------|------|
| ✅ | Schedule → ScheduleListResponseDto 변환 적용 |
| ✅ | Page<Schedule> → Page<ScheduleListResponseDto> 매핑 |
| ✅ | PageResponseDto 사용하여 페이징 응답 형식 통일 |
| ✅ | 서비스 내부 로직 정리 및 가독성 향상 |

## 🧪 테스트 확인 항목
- [ ] 조건 없이 전체 일정 페이징 조회
- [ ] userId 조건만 필터링
- [ ] updatedDateStr만 필터링
- [ ] userId + updatedDateStr 모두 필터링
